### PR TITLE
update kube/helm versions, + support for helm3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.6
 
 
-ARG KUBE_VERSION="v1.8.1"
+ARG KUBE_VERSION="v1.14.3"
 
-ARG HELM_VERSION="v2.7.0"
+ARG HELM_VERSION="v2.12.3"
 
 ENV FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
@@ -19,14 +19,14 @@ RUN apk add --update ca-certificates && update-ca-certificates \
     && pip install yq \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && curl -L http://storage.googleapis.com/kubernetes-helm/${FILENAME} -o /tmp/${FILENAME} \
+    && curl -L https://get.helm.sh/${FILENAME} -o /tmp/${FILENAME} \
     && tar -zxvf /tmp/${FILENAME} -C /tmp \
     && mv /tmp/linux-amd64/helm /bin/helm \
     # Cleanup uncessary files
     && rm /var/cache/apk/* \
     && rm -rf /tmp/*
 
-RUN helm init --client-only
+RUN if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi
 WORKDIR /config
 
 CMD bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG KUBE_VERSION="v1.14.3"
 
 ARG HELM_VERSION="v2.12.3"
 
-ENV FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+RUN echo "HELM_VERSION is set to: ${HELM_VERSION}"
+
+ENV FILENAME="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
 
 RUN apk add --update ca-certificates && update-ca-certificates \
     && apk add --update curl \
@@ -26,7 +28,7 @@ RUN apk add --update ca-certificates && update-ca-certificates \
     && rm /var/cache/apk/* \
     && rm -rf /tmp/*
 
-RUN if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi
+RUN bash -c 'if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; else echo "using helm3, no need to initialize helm"; fi'
 WORKDIR /config
 
 CMD bash


### PR DESCRIPTION
* Updated default ARGs for `KUBE_VERSION` (now 1.14.3) and `HELM_VERSION` (now 2.12.3)
* Changed curl location for HELM to use https://get.helm.sh
* Added check for `HELM_VERSION` 2.* vs 3.* since a home directory is no longer needed for Helm (now follows the XDG directory spec for storing files, `helm init` and `helm home` have been removed in helm3)
* echos `HELM_VERSION` in output for additional logging
* standardize FILENAME env variable for consistency (previously would have to set `HELM_VERSION` to `**v**X.X.X` but the `cfstep-helm` uses a numeric env var only (X.X.X I.E 2.14.3)